### PR TITLE
Fix deque front elements slicing.

### DIFF
--- a/src/deque.js
+++ b/src/deque.js
@@ -159,7 +159,7 @@ class Deque {
    */
   toArray() {
     const backElements = this._backElements.slice(this._backOffset);
-    const frontElements = this._frontElements.slice(this._frontElements);
+    const frontElements = this._frontElements.slice(this._frontOffset);
     return frontElements.reverse().concat(backElements);
   }
 

--- a/test/deque.test.js
+++ b/test/deque.test.js
@@ -88,6 +88,11 @@ describe('Deque unit tests', () => {
     it('should convert the deque into an array', () => {
       expect(deque.toArray()).to.deep.equal([2, 3, 4, 5]);
     });
+
+    it('should convert a deque with single array element', () => {
+      const dq = new Deque([1]);
+      expect(dq.toArray()).to.deep.equal([1]);
+    });
   });
 
   describe('popFront/popBack', () => {


### PR DESCRIPTION
The fix addresses the [issue](https://github.com/datastructures-js/deque/issues/7).

- fixed a typo in _frontElements slice, when calling `.toArray`
- added new test case
